### PR TITLE
bugfix, nextMonth util fn: returned date is initialized with day=1, a…

### DIFF
--- a/src/components/util.js
+++ b/src/components/util.js
@@ -1,15 +1,19 @@
 const nextMonth = (date) => {
-    let passYear = date.getMonth() === 11
-    let newMonth = passYear ? 0 : date.getMonth() + 1
-    let year = passYear ? date.getFullYear() + 1 : date.getFullYear()
-    return new Date(year, newMonth, date.getDate())
+
+    let passYear = date.getMonth() === 11,
+      year = passYear ? date.getFullYear() + 1 : date.getFullYear(),
+      newMonth = passYear ? 0 : date.getMonth() + 1;
+
+    return new Date(year, newMonth, 1);
 }
 
 const prevMonth = (date) => {
-    let passYear = date.getMonth() === 0
-    let newMonth = passYear ? 11 : date.getMonth() - 1
-    let year = passYear ? date.getFullYear() - 1 : date.getFullYear()
-    return new Date(year, newMonth, date.getDate())
+
+    let passYear = date.getMonth() === 0,
+      newMonth = passYear ? 11 : date.getMonth() - 1,
+      year = passYear ? date.getFullYear() - 1 : date.getFullYear();
+
+    return new Date(year, newMonth, 1);
 }
 
 export { nextMonth, prevMonth }


### PR DESCRIPTION
Bug with nextMonth fn that shows when the nextMonth (right side calendar) is shorter then the date.getDate().

As only the month is used here, it is reasonable to initialize it with day=1 to avoid this.