### PR TITLE
This fixes an issue with the hour being off by one.

### DIFF
--- a/src/components/CalendarTime.vue
+++ b/src/components/CalendarTime.vue
@@ -92,9 +92,20 @@
       },
     },
     methods: {
+      getHour() {
+        if (this.hour24) {
+          return this.hour;
+        } else {
+         if (this.hour === 12) {
+           return this.ampm === 'AM' ? 0 : 12;
+         } else {
+           return this.hour + (this.ampm === 'PM' ? 12 : 0);
+         }
+        }
+      },
       onChange () {
         this.$emit('update', {
-          hours: this.hour24? this.hour : (this.hour - 1 + (this.ampm === 'AM'? 0:12)),
+          hours: this.getHour(),
           minutes: this.minute,
           seconds: this.second,
         });

--- a/src/components/CalendarTime.vue
+++ b/src/components/CalendarTime.vue
@@ -53,7 +53,7 @@
     data() {
       let hours = this.currentTime.getHours();
       return {
-        hour: this.hour24 ? hours : hours % 12,
+        hour: this.hour24 ? hours : hours % 12 || 12,
         minute: this.currentTime.getMinutes() - (this.currentTime.getMinutes() % this.miniuteIncrement),
         second: this.currentTime.getSeconds(),
         ampm: hours < 12 ? 'AM' : 'PM',

--- a/src/components/CalendarTime.vue
+++ b/src/components/CalendarTime.vue
@@ -53,7 +53,7 @@
     data() {
       let hours = this.currentTime.getHours();
       return {
-        hour: this.hour24 ? hours : hours % 12 + 1,
+        hour: this.hour24 ? hours : hours % 12,
         minute: this.currentTime.getMinutes() - (this.currentTime.getMinutes() % this.miniuteIncrement),
         second: this.currentTime.getSeconds(),
         ampm: hours < 12 ? 'AM' : 'PM',


### PR DESCRIPTION
The hour was previously off by one for non24 times. The new logic is correct.
```
let d = new Date()
for (let i =0; i < 24; i++) {
    d.setHours(i);
    console.log(d.getHours() % 12 || 12, d.getHours() % 12 + 1, d.toString())
}
New logic hour, Old logic hour, Actual Time
12 1 "Wed Apr 17 2019 00:18:17 GMT-0400 (Eastern Daylight Time)"
1 2 "Wed Apr 17 2019 01:18:17 GMT-0400 (Eastern Daylight Time)"
2 3 "Wed Apr 17 2019 02:18:17 GMT-0400 (Eastern Daylight Time)"
3 4 "Wed Apr 17 2019 03:18:17 GMT-0400 (Eastern Daylight Time)"
4 5 "Wed Apr 17 2019 04:18:17 GMT-0400 (Eastern Daylight Time)"
5 6 "Wed Apr 17 2019 05:18:17 GMT-0400 (Eastern Daylight Time)"
6 7 "Wed Apr 17 2019 06:18:17 GMT-0400 (Eastern Daylight Time)"
7 8 "Wed Apr 17 2019 07:18:17 GMT-0400 (Eastern Daylight Time)"
8 9 "Wed Apr 17 2019 08:18:17 GMT-0400 (Eastern Daylight Time)"
9 10 "Wed Apr 17 2019 09:18:17 GMT-0400 (Eastern Daylight Time)"
10 11 "Wed Apr 17 2019 10:18:17 GMT-0400 (Eastern Daylight Time)"
11 12 "Wed Apr 17 2019 11:18:17 GMT-0400 (Eastern Daylight Time)"
12 1 "Wed Apr 17 2019 12:18:17 GMT-0400 (Eastern Daylight Time)"
1 2 "Wed Apr 17 2019 13:18:17 GMT-0400 (Eastern Daylight Time)"
2 3 "Wed Apr 17 2019 14:18:17 GMT-0400 (Eastern Daylight Time)"
3 4 "Wed Apr 17 2019 15:18:17 GMT-0400 (Eastern Daylight Time)"
4 5 "Wed Apr 17 2019 16:18:17 GMT-0400 (Eastern Daylight Time)"
5 6 "Wed Apr 17 2019 17:18:17 GMT-0400 (Eastern Daylight Time)"
6 7 "Wed Apr 17 2019 18:18:17 GMT-0400 (Eastern Daylight Time)"
7 8 "Wed Apr 17 2019 19:18:17 GMT-0400 (Eastern Daylight Time)"
8 9 "Wed Apr 17 2019 20:18:17 GMT-0400 (Eastern Daylight Time)"
9 10 "Wed Apr 17 2019 21:18:17 GMT-0400 (Eastern Daylight Time)"
10 11 "Wed Apr 17 2019 22:18:17 GMT-0400 (Eastern Daylight Time)"
11 12 "Wed Apr 17 2019 23:18:17 GMT-0400 (Eastern Daylight Time)"
```