### PR TITLE
Enables use to have hour ranges. For example "Last  6 hours"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-daterange-picker",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Vue2 date range picker based on https://github.com/dangrossman/bootstrap-daterangepicker (no jQuery)",
   "author": "Nikola Kostadinov <nikolakk@gmail.com>",
   "main": "dist/vue2-daterange-picker.umd.min.js",

--- a/src/components/CalendarRanges.vue
+++ b/src/components/CalendarRanges.vue
@@ -23,7 +23,7 @@
     },
     methods: {
       range_class (range) {
-        return { active: moment(this.selected.startDate).isSame(range[0], 'date') && moment(this.selected.endDate).isSame(range[1], 'date') };
+        return { active: moment(this.selected.startDate).isSame(range[0]) && moment(this.selected.endDate).isSame(range[1]) };
       }
     },
   }

--- a/src/components/CalendarTime.vue
+++ b/src/components/CalendarTime.vue
@@ -79,6 +79,13 @@
       },
     },
     watch: {
+      currentTime (newTime) {
+        let hours = newTime.getHours();
+        this.hour = this.hour24 ? hours : hours % 12 || 12;
+        this.minute = newTime.getMinutes() - (newTime.getMinutes() % this.miniuteIncrement);
+        this.second = newTime.getSeconds();
+        this.ampm = hours < 12 ? 'AM' : 'PM';
+      },
       hour () {
         this.onChange();
       },


### PR DESCRIPTION
### Why?
Currently, if you try to make ranges such as:

```
return {
        'Last hour': [moment().subtract(1, 'hour'), moment()],
        'Last  6hours': [moment().subtract(6, 'hours'), moment()],
        'Last  12hours': [moment().subtract(12, 'hours'), moment()],
        Today: [moment(), moment()],
        Yesterday: [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
}
```
CalendarRanges.vue would make `'Last hour', 'Last 6hours' and 'Last 12hours'` active in the same time and CalendarTime.vue would not update hours when different range would be selected. 

This request fixes these problems.
