### PR TITLE
Feature: disabled state & custom container class

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vue-daterange-picker" @click.stop>
-    <div class="form-control reportrange-text" @click="togglePicker(null, true)">
+    <div :class="controlContainerClass" @click="onClickPicker">
       <!--
         Allows you to change the input which is visible before the picker opens
 
@@ -313,6 +313,20 @@
         type: [Object, String],
         default: 'native'
       },
+      /**
+       * Disabled state. If true picker do not popup on click.
+       */
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+      /**
+       * Class of html picker control container
+       */
+      controlContainerClass: {
+        type: [Object, String],
+        default: 'form-control reportrange-text'
+      },
     },
     data () {
       //copy locale data object
@@ -423,6 +437,11 @@
          * @param {Date} value the date that is being hovered
          */
         this.$emit('hoverDate', value)
+      },
+      onClickPicker () {
+        if (!this.disabled) {
+          this.togglePicker(null, true)
+        }
       },
       togglePicker (value, event) {
         if (typeof value === 'boolean') {


### PR DESCRIPTION
1. Disabled state - to prevent picker popup
2. Hardcoded classes `form-control reportrange-text` makes some trouble when using custom `input` slot. For example:
![изображение](https://user-images.githubusercontent.com/12033941/73205017-ae9fb200-4172-11ea-8e09-16feaee15110.png)
- there is simple bootstrap's input-group:
![изображение](https://user-images.githubusercontent.com/12033941/73205228-2ff74480-4173-11ea-949f-f6418766567d.png)

So I just make it possible to override this hardcoded classes.