### PR TITLE
Feature/select event

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -424,7 +424,7 @@
             this.start = this.normalizeDatetime(value, this.start);
           }
           if (!this.in_selection) {
-            this.$emit('select', {startDate: this.start, endDate: this.end});
+            this.onSelect();
             if (this.autoApply)
               this.clickedApply();
           }
@@ -434,7 +434,7 @@
           if (!this.singleDatePicker) {
             this.in_selection = true
           } else {
-            this.$emit('select', {startDate: this.start, endDate: this.end});
+            this.onSelect();
             if (this.autoApply)
               this.clickedApply();
           }
@@ -480,6 +480,13 @@
          */
         this.$emit('update', {startDate: this.start, endDate: this.end})
       },
+      onSelect () {
+        /**
+         * Emits when the user selects a range from the picker.
+         * @param {json} value - json object containing the dates: {startDate, endDate}
+         */
+        this.$emit('select', {startDate: this.start, endDate: this.end})
+      },
       clickAway () {
         if (this.open) {
           // reset start and end
@@ -506,7 +513,7 @@
           this.end = null
         }
 
-        this.$emit('select', {startDate: this.start, endDate: this.end});
+        this.onSelect();
 
         if (this.autoApply)
           this.clickedApply()

--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -423,16 +423,20 @@
             this.in_selection = true
             this.start = this.normalizeDatetime(value, this.start);
           }
-          if (!this.in_selection && this.autoApply) {
-            this.clickedApply();
+          if (!this.in_selection) {
+            this.$emit('select', {startDate: this.start, endDate: this.end});
+            if (this.autoApply)
+              this.clickedApply();
           }
         } else {
           this.start = this.normalizeDatetime(value, this.start);
           this.end = this.normalizeDatetime(value, this.end);
           if (!this.singleDatePicker) {
             this.in_selection = true
-          } else if (this.autoApply) {
-            this.clickedApply();
+          } else {
+            this.$emit('select', {startDate: this.start, endDate: this.end});
+            if (this.autoApply)
+              this.clickedApply();
           }
         }
       },
@@ -501,6 +505,8 @@
           this.start = null
           this.end = null
         }
+
+        this.$emit('select', {startDate: this.start, endDate: this.end});
 
         if (this.autoApply)
           this.clickedApply()


### PR DESCRIPTION
This PR adds a new event `select`, emitted when the user selects a range in the picker. 

I've found the need for this event because I needed to know what the user was selecting before actually applying. In fact, when `auto-apply` is enabled `select` will be triggered together with `update`. 

I've being using it for a few days and it has been working pretty reliably so far. Please let me know if this makes sense to be merged or if you have other suggestions on how to achieve the same behavior implemented here.