### PR TITLE
Fix singleDatePicker usages in conditions

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -482,7 +482,7 @@
         this.monthDate = newDate
         if (this.linkedCalendars || (this.$dateUtil.yearMonth(this.monthDate) >= this.$dateUtil.yearMonth(this.nextMonthDate))) {
           this.nextMonthDate = this.$dateUtil.validateDateRange(this.$dateUtil.nextMonth(newDate), this.minDate, this.maxDate);
-          if (!this.singleDatePicker && this.$dateUtil.yearMonth(this.monthDate) === this.$dateUtil.yearMonth(this.nextMonthDate)) {
+          if ((!this.singleDatePicker || this.singleDatePicker === 'range') && this.$dateUtil.yearMonth(this.monthDate) === this.$dateUtil.yearMonth(this.nextMonthDate)) {
             this.monthDate = this.$dateUtil.validateDateRange(this.$dateUtil.prevMonth(this.monthDate), this.minDate, this.maxDate)
           }
         }
@@ -584,7 +584,7 @@
          * Emits when the user selects a range from the picker and clicks "apply" (if autoApply is true).
          * @param {json} value - json object containing the dates: {startDate, endDate}
          */
-        this.$emit('update', {startDate: this.start, endDate: this.singleDatePicker ? this.start : this.end})
+        this.$emit('update', {startDate: this.start, endDate: this.singleDatePicker && this.singleDatePicker !== 'range' ? this.start : this.end})
       },
       clickCancel () {
         if (this.open) {
@@ -642,7 +642,7 @@
 
         // if autoapply is ON we should update the value on time selection change
         if (this.autoApply) {
-          this.$emit('update', {startDate: this.start, endDate: this.singleDatePicker ? this.start : this.end})
+          this.$emit('update', {startDate: this.start, endDate: this.singleDatePicker && this.singleDatePicker !== 'range' ? this.start : this.end})
         }
       },
       onUpdateEndTime (value) {


### PR DESCRIPTION
After the "range" option of singleDatePicker prop has been introduced in commit 719b842c27068116a6b584cac16e31de17510249, not all usages of this property got tweaked.

We should check for the "range" string value explicitly because that string converts to true, leaving some conditions work as if the picker was not in range mode.