### PR TITLE
Using event.composedPath to replace event.target

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -605,8 +605,8 @@
         this.$emit('select', {startDate: this.start, endDate: this.end})
       },
       clickAway ($event) {
-        if ($event && $event.target &&
-          !this.$el.contains($event.target) &&
+        if ($event && $event.composedPath &&
+          !this.$el.contains($event.composedPath()[0]) &&
           this.$refs.dropdown &&
           !this.$refs.dropdown.contains($event.target)) {
           this.clickCancel()


### PR DESCRIPTION
When we use this date range picker in a **custom element**. The date picker should be opened when the user clicks the date range input. But actually, it doesn't work.

We spiked the root cause, in a normal DOM, the `clickAway` handler was added in the `document.body`, the `event.target` is the date range `span`. But if in a shadow root, the `event.target` is the host element of the shadow root.

change to use `composedPath()` function. it could work in both cases normal elemenmt and shadow root.