### PR TITLE
Choosing "Yesterday" quick option gives range of 0 interval

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -315,16 +315,20 @@
           let today = new Date()
           today.setHours(0, 0, 0, 0)
 
-          let yesterday = new Date()
-          yesterday.setDate(today.getDate() - 1)
-          yesterday.setHours(0, 0, 0, 0);
+          let yesterdayStart = new Date()
+          yesterdayStart.setDate(today.getDate() - 1)
+          yesterdayStart.setHours(0, 0, 0, 0);
+
+          let yesterdayEnd = new Date()
+          yesterdayEnd.setDate(today.getDate() - 1)
+          yesterdayEnd.setHours(11, 59, 59, 999);
 
           let thisMonthStart = new Date(today.getFullYear(), today.getMonth(), 1);
           let thisMonthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
 
           return {
             'Today': [today, today],
-            'Yesterday': [yesterday, yesterday],
+            'Yesterday': [yesterdayStart, yesterdayEnd],
             'This month': [thisMonthStart, thisMonthEnd],
             'This year': [new Date(today.getFullYear(), 0, 1), new Date(today.getFullYear(), 11, 31)],
             'Last month': [new Date(today.getFullYear(), today.getMonth() - 1, 1), new Date(today.getFullYear(), today.getMonth(), 0)],


### PR DESCRIPTION
The start and end timestamp happens to be same which is worng it needs
to be start of day(00:00am) and end of day(11:59pm) respectively

[#241](https://github.com/Innologica/vue2-daterange-picker/issues/241)