### PR TITLE
Even If close the calendar, "in_selection" will still be true.

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -594,6 +594,7 @@
           this.start = startDate ? new Date(startDate) : null
           this.end = endDate ? new Date(endDate) : null
           // this.open = false
+          this.in_selection = false;
           this.togglePicker(false, true)
         }
       },


### PR DESCRIPTION
hi.
This PR is for #231.

# Problems
Select and close only the start date. 
The "in_selection" is still true, so the input was from the end date.
So, Make sure to set it to false when close it


Thanks for the great project!