### PR TITLE
Fix for hovered date changing initial date selection

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -590,13 +590,15 @@ export default {
     hoverDate (value) {
       if (this.readonly)
         return false
-      let dt_end = this.normalizeDatetime(value, this.end);
-      let dt_start = this.normalizeDatetime(value, this.start);
       if (this.in_selection) {
-        if (this.in_selection <= dt_end)
-          this.end = dt_end
-        if (this.in_selection >= dt_start)
-          this.start = dt_start
+        const in_selection = this.normalizeDatetime(value, this.in_selection);
+        if (value < in_selection) {
+          this.start = value
+          this.end = in_selection
+        } else {
+          this.start = in_selection
+          this.end = value
+        }
       }
       /**
        * Emits event when the mouse hovers a date


### PR DESCRIPTION
**Problem:** For date ranges, after initial date is selected, hover over a date that comes before the initial selection and then hover over a date that comes after initial selection. See that initial date selection has changed.

**Expected results:** Hovering on dates before or after initial date selection should not change initial date.