### PR TITLE
Fix isClear for singleDatePicker

### DIFF
--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -768,7 +768,7 @@ export default {
       }
     },
     isClear () {
-      return !this.dateRange.startDate || !this.dateRange.endDate
+      return !this.dateRange.startDate || !(this.dateRange.endDate || this.singleDatePicker)
     },
     isDirty () {
       let origStart = new Date(this.dateRange.startDate)


### PR DESCRIPTION
Inside isClear computed property, don't check if endDate is set when using singleDatePicker.
Without this fix, the dateRange.startDate does not properly set this.start data property.

To reproduce the issue, programmatically toggle the picker with singleDatePicker and initial property without endDate set. 
You will see that the passed in startDate date and time are not selected in the popup.
To verify this issue, if you set the endDate to `new Date()`, then date and time are properly selected on picker toggle.